### PR TITLE
Crash in PhotoViewAttacher after the view is gone

### DIFF
--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -938,6 +938,10 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener, Vers
 
 		@Override
 		public void run() {
+			if (mScroller.isFinished()) {
+				return; // remaining post that should not be handled
+			}
+			
 			ImageView imageView = getImageView();
 			if (null != imageView && mScroller.computeScrollOffset()) {
 

--- a/library/src/uk/co/senab/photoview/ScrollerProxy.java
+++ b/library/src/uk/co/senab/photoview/ScrollerProxy.java
@@ -39,6 +39,8 @@ public abstract class ScrollerProxy {
 
 	public abstract void forceFinished(boolean finished);
 
+	public abstract boolean isFinished();
+
 	public abstract int getCurrX();
 
 	public abstract int getCurrY();
@@ -66,6 +68,11 @@ public abstract class ScrollerProxy {
 		@Override
 		public void forceFinished(boolean finished) {
 			mScroller.forceFinished(finished);
+		}
+		
+		@Override
+		public boolean isFinished() {
+			return mScroller.isFinished();
 		}
 
 		@Override
@@ -101,6 +108,10 @@ public abstract class ScrollerProxy {
 		@Override
 		public void forceFinished(boolean finished) {
 			mScroller.forceFinished(finished);
+		}
+
+		public boolean isFinished() {
+			return mScroller.isFinished();
 		}
 
 		@Override


### PR DESCRIPTION
I also get crashes when the fling is still being run but the view is gone.
The patch not tested in production yet, extra tests in the fling Runnable may be necessary

This is the kinf of crash I get:
java.lang.IllegalStateException: ImageView no longer exists. You should not use this PhotoViewAttacher any more.
    at uk.co.senab.photoview.PhotoViewAttacher.getImageView(PhotoViewAttacher.java:226)
    at uk.co.senab.photoview.PhotoViewAttacher$FlingRunnable.run(PhotoViewAttacher.java:909)
    at android.os.Handler.handleCallback(Handler.java:615)
    at android.os.Handler.dispatchMessage(Handler.java:92)
    at android.os.Looper.loop(Looper.java:137)
    at android.app.ActivityThread.main(ActivityThread.java:4898)
    at java.lang.reflect.Method.invokeNative(Native Method)
    at java.lang.reflect.Method.invoke(Method.java:511)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1006)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:773)
    at dalvik.system.NativeStart.main(Native Method)
