### PR TITLE
disableMidScale() added to IPhotoView.

### DIFF
--- a/library/src/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/uk/co/senab/photoview/IPhotoView.java
@@ -47,6 +47,11 @@ public interface IPhotoView {
      */
     float getMidScale();
 
+	/**
+	 * @return true if middle scale level is disabled.
+	 */
+	boolean isMidScaleDisabled();
+
     /**
      * @return The current maximum scale level. What this value represents depends on the current {@link android.widget.ImageView.ScaleType}.
      */
@@ -78,6 +83,11 @@ public interface IPhotoView {
      * Sets the middle scale level. What this value represents depends on the current {@link android.widget.ImageView.ScaleType}.
      */
     void setMidScale(float midScale);
+
+	/**
+	 * Disables the middle scsale level.
+	 */
+	void disableMidScale();
 
     /**
      * Sets the maximum scale level. What this value represents depends on the current {@link android.widget.ImageView.ScaleType}.

--- a/library/src/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/uk/co/senab/photoview/PhotoView.java
@@ -71,6 +71,11 @@ public class PhotoView extends ImageView implements IPhotoView {
 	}
 
 	@Override
+	public boolean isMidScaleDisabled() {
+		return mAttacher.isMidScaleDisabled();
+	}
+
+	@Override
 	public float getMaxScale() {
 		return mAttacher.getMaxScale();
 	}
@@ -98,6 +103,11 @@ public class PhotoView extends ImageView implements IPhotoView {
 	@Override
 	public void setMidScale(float midScale) {
 		mAttacher.setMidScale(midScale);
+	}
+
+	@Override
+	public void disableMidScale() {
+		mAttacher.disableMidScale();
 	}
 
 	@Override

--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -53,6 +53,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener, Vers
 	private float mMaxScale = DEFAULT_MAX_SCALE;
 
     private boolean mAllowParentInterceptOnEdge = true;
+	private boolean mMidScaleEnabled = true;
 
 	private static void checkZoomLevels(float minZoom, float midZoom, float maxZoom) {
 		if (minZoom >= midZoom) {
@@ -224,6 +225,11 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener, Vers
 	}
 
 	@Override
+	public boolean isMidScaleDisabled() {
+		return !mMidScaleEnabled;
+	}
+
+	@Override
 	public float getMaxScale() {
 		return mMaxScale;
 	}
@@ -244,12 +250,20 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener, Vers
 			float x = ev.getX();
 			float y = ev.getY();
 
-			if (scale < mMidScale) {
-				zoomTo(mMidScale, x, y);
-			} else if (scale >= mMidScale && scale < mMaxScale) {
-				zoomTo(mMaxScale, x, y);
+			if (mMidScaleEnabled) {
+				if (scale < mMidScale) {
+					zoomTo(mMidScale, x, y);
+				} else if (scale >= mMidScale && scale < mMaxScale) {
+					zoomTo(mMaxScale, x, y);
+				} else {
+					zoomTo(mMinScale, x, y);
+				}
 			} else {
-				zoomTo(mMinScale, x, y);
+				if (scale < mMaxScale) {
+					zoomTo(mMaxScale, x, y);
+				} else {
+					zoomTo(mMinScale, x, y);
+				}
 			}
 		} catch (ArrayIndexOutOfBoundsException e) {
 			// Can sometimes happen when getX() and getY() is called
@@ -435,6 +449,11 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener, Vers
 	public void setMidScale(float midScale) {
 		checkZoomLevels(mMinScale, midScale, mMaxScale);
 		mMidScale = midScale;
+	}
+
+	@Override
+	public void disableMidScale() {
+		this.mMidScaleEnabled = false;
 	}
 
 	@Override


### PR DESCRIPTION
In some cases, we do not want middle scale level on double tapping.
However, there's no way to disable it.
So I added a member function to do so.
