### PR TITLE
Allow parent, such as ViewPager, to scroll if no Drawable loaded into PhotoView

### DIFF
--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -300,11 +300,11 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener, Vers
 					imageView.getParent().requestDisallowInterceptTouchEvent(false);
 				}
 			}
+		}
 
-			// allow pager to scroll to next item if image has not been loaded
-			if (!hasDrawable(imageView)) {
-				imageView.getParent().requestDisallowInterceptTouchEvent(false);
-			}
+		// allow pager to scroll to next item if image has not been loaded
+		if (!hasDrawable(imageView)) {
+			imageView.getParent().requestDisallowInterceptTouchEvent(false);
 		}
 	}
 


### PR DESCRIPTION
Hello Chris,

I'm not sure if this is desired or not, but I added an if statement in onDrag() in PhotoViewAttacher that allows parent scrolling if no image has been loaded into PhotoView. 

This is useful if the user wants to continue scrolling items in a ViewPager even though the current item has not been loaded.

Thanks,

Igor
