### PR TITLE
Removed dependency to android support library

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,9 +1,5 @@
 apply plugin: 'android-library'
 
-dependencies {
-    compile 'com.android.support:support-v4:18.0.+'
-}
-
 android {
     compileSdkVersion 18
     buildToolsVersion '18.0.1'


### PR DESCRIPTION
The dependency to the `com.android.support:support-v4:18.0.+` is not needed in the library module. This PR removes the dependency in the library `build.gradle`.
