### PR TITLE
Do not drag if we are already scaling.

### DIFF
--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -346,6 +346,10 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
 
     @Override
     public final void onDrag(float dx, float dy) {
+        if (mScaleDragDetector.isScaling()) {
+            return; // Do not drag if we are already scaling
+        }
+
         if (DEBUG) {
             LogManager.getLogger().d(LOG_TAG,
                     String.format("onDrag: dx: %.2f. dy: %.2f", dx, dy));
@@ -364,7 +368,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
          * on, and the direction of the scroll (i.e. if we're pulling against
          * the edge, aka 'overscrolling', let the parent take over).
          */
-        if (mAllowParentInterceptOnEdge && !mScaleDragDetector.isScaling()) {
+        if (mAllowParentInterceptOnEdge) {
             if (mScrollEdge == EDGE_BOTH
                     || (mScrollEdge == EDGE_LEFT && dx >= 1f)
                     || (mScrollEdge == EDGE_RIGHT && dx <= -1f)) {


### PR DESCRIPTION
Scaling does not zoom to the correct focal point. This is due to the fact that we are allowing dragging and scaling at the same time. I've disabled dragging when we are scaling in onDrag.
