### PR TITLE
Allow images to be zoomed in when double clicked.

### DIFF
--- a/library/src/uk/co/senab/photoview/DefaultOnDoubleTapListener.java
+++ b/library/src/uk/co/senab/photoview/DefaultOnDoubleTapListener.java
@@ -75,7 +75,7 @@ public class DefaultOnDoubleTapListener implements GestureDetector.OnDoubleTapLi
             float x = ev.getX();
             float y = ev.getY();
 
-            if (scale < photoViewAttacher.getMinimumScale()) {
+            if (scale < photoViewAttacher.getMediumScale()) {
                 photoViewAttacher.setScale(photoViewAttacher.getMediumScale(), x, y, true);
             } else if (scale >= photoViewAttacher.getMediumScale() && scale < photoViewAttacher.getMaximumScale()) {
                 photoViewAttacher.setScale(photoViewAttacher.getMaximumScale(), x, y, true);


### PR DESCRIPTION
Modified the onDoubleTap method to first check if the scale is less than the medium scale. 

This was the case until edd339327 when this was changed to getMinimumScale which stopped images zooming in on double tap.
