### PR TITLE
Zoom enabled false fix and fix for allowing flexibility for new IPhotoView classes

### DIFF
--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -432,6 +432,9 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
                 mIvLeft = left;
             }
         }
+        else {
+        	updateBaseMatrix(imageView.getDrawable());
+        }
     }
 
     public final void onScale(float scaleFactor, float focusX, float focusY) {


### PR DESCRIPTION
**Fixes for two bugs I ran into:**
1) One prevented me from implementing my own PhotoView class (_as I could not extend PhotoView directly due to needing a pre-existing base class_).

2) When you set Zoomable to false, it was not properly scaling as FIT_CENTER. Instead it was just displaying actual size. No scaling. (_Identity base matrix_)
