### PR TITLE
Return the draw matrix instead of the supplemental matrix on getDisplayMatrix

### DIFF
--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -670,7 +670,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
 
     @Override
     public Matrix getDisplayMatrix() {
-        return new Matrix(mSuppMatrix);
+        return new Matrix(getDrawMatrix());
     }
 
     protected Matrix getDrawMatrix() {


### PR DESCRIPTION
For the display matrix returned from the attacher's getDisplayMatrix, return the composition of local changes with the changes based on the scaling type of the base imageView.

I don't know enough about the original intention of getDisplayMatrix to know what the intent was here, but:

1) returning the drawing matrix seems way more useful in the common case, where you just want a matrix to replicate the changes you see onscreen in the PhotoView
2) This means that the getDisplayMatrix behavior is the same between PhotoView and PhotoViewAttacher

Both of those together, along with there not being a great way to get at #1 otherwise, made me think this might be a useful change to make. If not, adding a similar function seems required, unless I'm missing another way clients should be getting at this.
