### PR TITLE
Improved Photo Rotation API

### DIFF
--- a/library/src/uk/co/senab/photoview/IPhotoView.java
+++ b/library/src/uk/co/senab/photoview/IPhotoView.java
@@ -181,6 +181,20 @@ public interface IPhotoView {
      * @param listener - Listener to be registered.
      */
     void setOnViewTapListener(PhotoViewAttacher.OnViewTapListener listener);
+    
+    /**
+     * Enables rotation via PhotoView internal functions.
+     *
+     * @param rotationDegree - Degree to rotate PhotoView to, should be in range 0 to 360
+     */
+    void setRotationTo(float rotationDegree);
+    
+    /**
+     * Enables rotation via PhotoView internal functions.
+     *
+     * @param rotationDegree - Degree to rotate PhotoView by, should be in range 0 to 360
+     */
+     void setRotationBy(float rotationDegree);
 
     /**
      * Changes the current scale to the specified value.
@@ -229,24 +243,8 @@ public interface IPhotoView {
      * Name is chosen so it won't collide with View.setRotation(float) in API since 11
      *
      * @param rotationDegree - Degree to rotate PhotoView to, should be in range 0 to 360
-     * @deprecated use {@link #setPhotoViewRotationTo(float)}
+     * @deprecated use {@link #setRotationTo(float)}
      */
     void setPhotoViewRotation(float rotationDegree);
-    
-    /**
-     * Enables rotation via PhotoView internal functions.
-     * Name is chosen so it won't collide with View.setRotation(float) in API since 11
-     *
-     * @param rotationDegree - Degree to rotate PhotoView to, should be in range 0 to 360
-     */
-    void setPhotoViewRotationTo(float rotationDegree);
-    
-    /**
-     * Enables rotation via PhotoView internal functions.
-     * Name is chosen so it won't collide with View.setRotation(float) in API since 11
-     *
-     * @param rotationDegree - Degree to rotate PhotoView by, should be in range 0 to 360
-     */
-    void setPhotoViewRotationBy(float rotationDegree);
 
 }

--- a/library/src/uk/co/senab/photoview/PhotoView.java
+++ b/library/src/uk/co/senab/photoview/PhotoView.java
@@ -53,7 +53,7 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
 
     /**
-     * @deprecated use {@link #setPhotoViewRotationTo(float)}
+     * @deprecated use {@link #setRotationTo(float)}
      */
     @Override
     public void setPhotoViewRotation(float rotationDegree) {
@@ -61,13 +61,13 @@ public class PhotoView extends ImageView implements IPhotoView {
     }
     
     @Override
-    public void setPhotoViewRotationTo(float rotationDegree) {
-        mAttacher.setPhotoViewRotationTo(rotationDegree);
+    public void setRotationTo(float rotationDegree) {
+        mAttacher.setRotationTo(rotationDegree);
     }
 
     @Override
-    public void setPhotoViewRotationBy(float rotationDegree) {
-        mAttacher.setPhotoViewRotationBy(rotationDegree);
+    public void setRotationBy(float rotationDegree) {
+        mAttacher.setRotationBy(rotationDegree);
     }
 
     @Override

--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -260,7 +260,7 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     }
 
     /**
-     * @deprecated use {@link #setPhotoViewRotationTo(float)}
+     * @deprecated use {@link #setRotationTo(float)}
      */
     @Override
     public void setPhotoViewRotation(float degrees) {
@@ -269,13 +269,13 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
     }
 
     @Override
-    public void setPhotoViewRotationTo(float degrees) {
+    public void setRotationTo(float degrees) {
         mSuppMatrix.setRotate(degrees % 360);
         checkAndDisplayMatrix();
     }
 
     @Override
-    public void setPhotoViewRotationBy(float degrees) {
+    public void setRotationBy(float degrees) {
         mSuppMatrix.postRotate(degrees % 360);
         checkAndDisplayMatrix();
     }


### PR DESCRIPTION
[Originally Requested [here](https://github.com/chrisbanes/PhotoView/pull/151#issuecomment-35374038)]
During development, I realized that the `setPhotoRotation` method existed (did not find at first because of the name). Once I used it I realized that it would only set the rotation from zero degrees - not from the current rotation matrix. 

Over a few revisions, I was able to improve the API by adding the methods `setRotationTo` and `setRotationBy` that rotate from zero or from the current rotation, respectively. Additionally, these do not conflict with any `View` methods, so these integrate better for someone looking for a rotation method to use.
