### PR TITLE
Remove final from onScale

### DIFF
--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -434,7 +434,8 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
         }
     }
 
-    public final void onScale(float scaleFactor, float focusX, float focusY) {
+    @Override
+	public void onScale(float scaleFactor, float focusX, float focusY) {
         if (DEBUG) {
             LogManager.getLogger().d(
                     LOG_TAG,


### PR DESCRIPTION
I needed to not allow the user to zoom over the mininum zoom.

So I extended PhotoViewAttacher and implemented the onScale, but he is final.

I believe that he doesn't need to be final, if there is another way to implement that, please let me know.
