### PR TITLE
Disable ViewPager navigation when interacting with ImageView

### DIFF
--- a/sample/res/menu/viewpager_menu.xml
+++ b/sample/res/menu/viewpager_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item
+        android:id="@+id/menu_lock"
+        android:showAsAction="always"
+        android:title="@string/menu_lock"/>
+
+</menu>

--- a/sample/res/values/strings.xml
+++ b/sample/res/values/strings.xml
@@ -14,5 +14,8 @@
     <string name="menu_zoom_random">Set scale to random value</string>
     <string name="menu_matrix_restore">Restore Display Matrix</string>
     <string name="menu_matrix_capture">Capture Display Matrix</string>
+    
+    <string name="menu_lock">Lock</string>
+    <string name="menu_unlock">Unlock</string>
 
 </resources>

--- a/sample/src/uk/co/senab/photoview/sample/HackyViewPager.java
+++ b/sample/src/uk/co/senab/photoview/sample/HackyViewPager.java
@@ -6,6 +6,13 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 
 /**
+ * Found at http://stackoverflow.com/questions/7814017/is-it-possible-to-disable-scrolling-on-a-viewpager.
+ * Convenient way to temporarily disable ViewPager navigation while interacting with ImageView.
+ * 
+ * Julia Zudikova
+ */
+
+/**
  * Hacky fix for Issue #4 and
  * http://code.google.com/p/android/issues/detail?id=18990
  * <p/>
@@ -20,22 +27,49 @@ import android.view.MotionEvent;
  */
 public class HackyViewPager extends ViewPager {
 
+	private boolean isLocked;
+	
     public HackyViewPager(Context context) {
         super(context);
+        isLocked = false;
     }
 
     public HackyViewPager(Context context, AttributeSet attrs) {
         super(context, attrs);
+        isLocked = false;
     }
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
-        try {
-            return super.onInterceptTouchEvent(ev);
-        } catch (IllegalArgumentException e) {
-            e.printStackTrace();
-            return false;
-        }
+    	if (!isLocked) {
+	        try {
+	            return super.onInterceptTouchEvent(ev);
+	        } catch (IllegalArgumentException e) {
+	            e.printStackTrace();
+	            return false;
+	        }
+    	}
+    	return false;
     }
 
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        if (!isLocked) {
+            return super.onTouchEvent(event);
+        }
+        return false;
+    }
+    
+	public void toggleLock() {
+		isLocked = !isLocked;
+	}
+
+	public void setLocked(boolean isLocked) {
+		this.isLocked = isLocked;
+	}
+
+	public boolean isLocked() {
+		return isLocked;
+	}
+	
 }

--- a/sample/src/uk/co/senab/photoview/sample/ViewPagerActivity.java
+++ b/sample/src/uk/co/senab/photoview/sample/ViewPagerActivity.java
@@ -15,26 +15,46 @@
  *******************************************************************************/
 package uk.co.senab.photoview.sample;
 
+import uk.co.senab.photoview.PhotoView;
 import android.app.Activity;
 import android.os.Bundle;
 import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.MenuItem.OnMenuItemClickListener;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
 
-import uk.co.senab.photoview.PhotoView;
+/**
+ * Lock/Unlock button is added to the ActionBar.
+ * Use it to temporarily disable ViewPager navigation in order to correctly interact with ImageView by gestures.
+ * Lock/Unlock state of ViewPager is saved and restored on configuration changes.
+ * 
+ * Julia Zudikova
+ */
 
 public class ViewPagerActivity extends Activity {
 
+	private static final String ISLOCKED_ARG = "isLocked";
+	
+	private ViewPager mViewPager;
+	private MenuItem menuLockItem;
+	
     @Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_view_pager);
-        ViewPager mViewPager = (HackyViewPager) findViewById(R.id.view_pager);
+        mViewPager = (HackyViewPager) findViewById(R.id.view_pager);
 		setContentView(mViewPager);
 
 		mViewPager.setAdapter(new SamplePagerAdapter());
+		
+		if (savedInstanceState != null) {
+			boolean isLocked = savedInstanceState.getBoolean(ISLOCKED_ARG, false);
+			((HackyViewPager) mViewPager).setLocked(isLocked);
+		}
 	}
 
 	static class SamplePagerAdapter extends PagerAdapter {
@@ -70,4 +90,55 @@ public class ViewPagerActivity extends Activity {
 
 	}
 
+	@Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.viewpager_menu, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+    
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        menuLockItem = menu.findItem(R.id.menu_lock);
+        toggleLockBtnTitle();
+        menuLockItem.setOnMenuItemClickListener(new OnMenuItemClickListener() {
+			@Override
+			public boolean onMenuItemClick(MenuItem item) {
+				toggleViewPagerScrolling();
+				toggleLockBtnTitle();
+				return true;
+			}
+		});
+
+        return super.onPrepareOptionsMenu(menu);
+    }
+    
+    private void toggleViewPagerScrolling() {
+    	if (isViewPagerActive()) {
+    		((HackyViewPager) mViewPager).toggleLock();
+    	}
+    }
+    
+    private void toggleLockBtnTitle() {
+    	boolean isLocked = false;
+    	if (isViewPagerActive()) {
+    		isLocked = ((HackyViewPager) mViewPager).isLocked();
+    	}
+    	String title = (isLocked) ? getString(R.string.menu_unlock) : getString(R.string.menu_lock);
+    	if (menuLockItem != null) {
+    		menuLockItem.setTitle(title);
+    	}
+    }
+
+    private boolean isViewPagerActive() {
+    	return (mViewPager != null && mViewPager instanceof HackyViewPager);
+    }
+    
+	@Override
+	protected void onSaveInstanceState(Bundle outState) {
+		if (isViewPagerActive()) {
+			outState.putBoolean(ISLOCKED_ARG, ((HackyViewPager) mViewPager).isLocked());
+    	}
+		super.onSaveInstanceState(outState);
+	}
+    
 }


### PR DESCRIPTION
Lock/Unlock button to temporarily disable ViewPager navigation in order to correctly interact with ImageView by gestures. Lock/Unlock state of ViewPager is saved and restored on configuration changes.
