### PR TITLE
Fix dragging gesture in views like ViewPager

### DIFF
--- a/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
+++ b/library/src/uk/co/senab/photoview/PhotoViewAttacher.java
@@ -518,14 +518,14 @@ public class PhotoViewAttacher implements IPhotoView, View.OnTouchListener,
                 handled = true;
             }
 
-            if (!handled && null != parent) {
-                parent.requestDisallowInterceptTouchEvent(false);
-            }
-
-            // Finally, try the Scale/Drag detector
+            // Try the Scale/Drag detector
             if (null != mScaleDragDetector
                     && mScaleDragDetector.onTouchEvent(ev)) {
                 handled = true;
+            }
+            
+            if (!handled && null != parent) {
+                parent.requestDisallowInterceptTouchEvent(false);
             }
         }
 


### PR DESCRIPTION
Move re-enabling touch event interception by parents (like ViewPager) after potential scaling/dragging gesture detection. So it avoids the use of HackyViewPager.
