### PR TITLE
Translate image during scale

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/CustomGestureDetector.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/CustomGestureDetector.java
@@ -48,6 +48,7 @@ class CustomGestureDetector {
 
         mListener = listener;
         ScaleGestureDetector.OnScaleGestureListener mScaleListener = new ScaleGestureDetector.OnScaleGestureListener() {
+            private float lastFocusX, lastFocusY = 0;
 
             @Override
             public boolean onScale(ScaleGestureDetector detector) {
@@ -58,13 +59,21 @@ class CustomGestureDetector {
              
                 if (scaleFactor >= 0) {
                     mListener.onScale(scaleFactor,
-                            detector.getFocusX(), detector.getFocusY());
+                            detector.getFocusX(),
+                            detector.getFocusY(),
+                            detector.getFocusX() - lastFocusX,
+                            detector.getFocusY() - lastFocusY
+                    );
+                    lastFocusX = detector.getFocusX();
+                    lastFocusY = detector.getFocusY();
                 }
                 return true;
             }
 
             @Override
             public boolean onScaleBegin(ScaleGestureDetector detector) {
+                lastFocusX = detector.getFocusX();
+                lastFocusY = detector.getFocusY();
                 return true;
             }
 

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/OnGestureListener.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/OnGestureListener.java
@@ -24,4 +24,5 @@ interface OnGestureListener {
 
     void onScale(float scaleFactor, float focusX, float focusY);
 
+    void onScale(float scaleFactor, float focusX, float focusY, float dx, float dy);
 }

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoViewAttacher.java
@@ -144,11 +144,17 @@ public class PhotoViewAttacher implements View.OnTouchListener,
 
         @Override
         public void onScale(float scaleFactor, float focusX, float focusY) {
+            onScale(scaleFactor, focusX, focusY, 0, 0);
+        }
+
+        @Override
+        public void onScale(float scaleFactor, float focusX, float focusY, float dx, float dy) {
             if (getScale() < mMaxScale || scaleFactor < 1f) {
                 if (mScaleChangeListener != null) {
                     mScaleChangeListener.onScaleChange(scaleFactor, focusX, focusY);
                 }
                 mSuppMatrix.postScale(scaleFactor, scaleFactor, focusX, focusY);
+                mSuppMatrix.postTranslate(dx, dy);
                 checkAndDisplayMatrix();
             }
         }


### PR DESCRIPTION
**This PR changes the behaviour of the scale action.**
Until now when the user scaled the image and the focus point has changed, we did not translate the image.
Now we translate the image as well allowing the user to zoom and pan the image simultaneously.

This change can be opt-in but I figured since this has become the expected behaviour by users it should be the default behaviour.


| Before | After|
|--------|------|
|   ![ezgif com-resize (2)](https://user-images.githubusercontent.com/12352397/85141344-4d769900-b24f-11ea-8eac-5b3024c83611.gif)   |   ![ezgif com-resize (1)](https://user-images.githubusercontent.com/12352397/85141529-94648e80-b24f-11ea-9a14-a845fb43b181.gif)   |
