### PR TITLE
Failing SonarQube CI builds due to "www" missing from gradle repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ allprojects {
 buildscript {
     repositories {
         maven { url "https://www.jitpack.io" }
+    }	
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this in your root `build.gradle` file (**not** your module `build.gradle` fi
 
 ```gradle
 allprojects {
-	repositories {
+    repositories {
         maven { url "https://www.jitpack.io" }
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@ Add this in your root `build.gradle` file (**not** your module `build.gradle` fi
 ```gradle
 allprojects {
 	repositories {
-        maven { url "https://jitpack.io" }
+        maven { url "https://www.jitpack.io" }
     }
+}
+
+buildscript {
+    repositories {
+        maven { url "https://www.jitpack.io" }
 }
 ```
 


### PR DESCRIPTION
My SonarQube task in my CI builds was failing with a:

```
  > Could not download PhotoView-2.0.0.aar (com.github.chrisbanes:PhotoView:2.0.0)
      > Could not get resource 'https://jitpack.io/com/github/chrisbanes/PhotoView/2.0.0/PhotoView-2.0.0.aar'.
         > Could not GET 'https://jitpack.io/com/github/chrisbanes/PhotoView/2.0.0/PhotoView-2.0.0.aar'.
            > Connection reset
```

I could not wrap my head around it and it was driving me nuts, turns out I had to add "www" to the jitpack URL and add it to the buildscript too.