### PR TITLE
Add configuration for MavenCentral publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ allprojects {
 Then, add the library to your module `build.gradle`
 ```gradle
 dependencies {
-    implementation 'com.github.chrisbanes:PhotoView:latest.release.here'
+    implementation 'com.baseflow:photoview:latest.release.here'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.6.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"
     }
 }
 
@@ -22,3 +23,5 @@ allprojects {
 ext {
     sdkVersion = 29
 }
+
+apply plugin: 'io.codearte.nexus-staging'

--- a/photoview/build.gradle
+++ b/photoview/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
 }
 
-def PUBLISH_GROUP_ID = 'com.github.chrisbanes'
-def PUBLISH_ARTIFACT_ID = 'PhotoView'
+def PUBLISH_GROUP_ID = 'com.baseflow'
+def PUBLISH_ARTIFACT_ID = 'photoview'
 def PUBLISH_VERSION = '2.3.0'
 
 ext["signing.keyId"] = ''
@@ -30,7 +30,6 @@ ext["sonatypeStagingProfileId"] = ''
 
 File localPropsFile = project.rootProject.file('local.properties')
 if (localPropsFile.exists()) {
-    println "Found local props file, loading props from there"
     Properties p = new Properties()
     new FileInputStream(localPropsFile).withCloseable { is ->
         p.load(is)
@@ -39,7 +38,6 @@ if (localPropsFile.exists()) {
         ext[name] = value
     }
 } else {
-    println "No local props file, loading env vars instead"
     ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
     ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')

--- a/photoview/build.gradle
+++ b/photoview/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 android {
     compileSdkVersion rootProject.ext.sdkVersion
@@ -16,24 +17,62 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.1.0"
 }
 
+def PUBLISH_GROUP_ID = 'com.github.chrisbanes'
+def PUBLISH_ARTIFACT_ID = 'PhotoView'
+def PUBLISH_VERSION = '2.3.0'
+
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+File localPropsFile = project.rootProject.file('local.properties')
+if (localPropsFile.exists()) {
+    println "Found local props file, loading props from there"
+    Properties p = new Properties()
+    new FileInputStream(localPropsFile).withCloseable { is ->
+        p.load(is)
+    }
+    p.each { name, value ->
+        ext[name] = value
+    }
+} else {
+    println "No local props file, loading env vars instead"
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+}
+
+nexusStaging {
+    packageGroup = PUBLISH_GROUP_ID
+    stagingProfileId = sonatypeStagingProfileId
+    username = ossrhUsername
+    password = ossrhPassword
+}
+
 afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
                 from components.release
 
-                group = 'com.github.chrisbanes'
-                artifactId = 'PhotoView'
-                version = '2.3.0'
+                groupId PUBLISH_GROUP_ID
+                artifactId PUBLISH_ARTIFACT_ID
+                version PUBLISH_VERSION
 
                 // Adds javadocs and sources as separate jars.
                 artifact androidJavadocsJar
                 artifact(sourceJar)
 
                 pom {
-                    name = 'PhotoView'
+                    name = PUBLISH_ARTIFACT_ID
                     description = 'A simple ImageView that support zooming, both by Multi-touch gestures and double-tap.'
-                    url = 'https://github.com/chrisbanes/PhotoView'
+                    url = 'https://github.com/Baseflow/PhotoView'
                     licenses {
                         license {
                             name = 'The Apache License, Version 2.0'
@@ -47,14 +86,33 @@ afterEvaluate {
                         }
                     }
                     scm {
-                        connection = 'scm:git@github.com/chrisbanes/PhotoView.git'
-                        developerConnection = 'scm:git@github.com/chrisbanes/PhotoView.git'
-                        url = 'https://github.com/chrisbanes/PhotoView'
+                        connection = 'scm:git@github.com/Baseflow/PhotoView.git'
+                        developerConnection = 'scm:git@github.com/Baseflow/PhotoView.git'
+                        url = 'https://github.com/Baseflow/PhotoView'
                     }
                 }
             }
         }
+
+        repositories {
+            maven {
+                name = "sonatype"
+
+                def releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+
+                credentials {
+                    username ossrhUsername
+                    password ossrhPassword
+                }
+            }
+        }
     }
+}
+
+signing {
+    sign publishing.publications
 }
 
 task androidJavadocs(type: Javadoc) {


### PR DESCRIPTION
Adds build configuration to publish the library to MavenCentral, based on [this article](https://blog.autsoft.hu/publishing-an-android-library-to-mavencentral-in-2019/) and [this library's config](https://github.com/rainbowcake/rainbowcake/blob/dev/scripts/publish-mavencentral.gradle).

This will require the following inputs:

- `signing.keyId`: the ID of the GPG key pair used for signing, the last eight characters of its fingerprint
- `signing.password`: the passphrase of the key pair
- `signing.secretKeyRingFile`: the location of the exported private key
- `ossrhUsername` and `osshrPassword`: login credentials for https://oss.sonatype.org/
- `stagingProfileId`: value from Sonatype

Usage:

- Set the values described above in `local.properties` or environment variables
- `./gradlew assembleRelease` (build)
- `./gradlew publishReleasePublicationToSonatypeRepository` (sign and upload artifact to Sonatype)
- `./gradlew closeAndReleaseRepository` (close and release Sonatype repo)

---

I didn't include CI config in the first draft, but it would be fairly easy and convenient to plug this all into GitHub Actions.