### PR TITLE
Add OnSwipeCloseListener

### DIFF
--- a/photoview/src/main/java/com/github/chrisbanes/photoview/OnSwipeCloseListener.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/OnSwipeCloseListener.java
@@ -1,0 +1,22 @@
+package com.github.chrisbanes.photoview;
+
+/**
+ * A callback to be invoked when swiped up or down
+ */
+public interface OnSwipeCloseListener {
+    /**
+     * A callback while swiping
+     * @param delta Amount of movement
+     */
+    void onProgress(float delta);
+
+    /**
+     * A callback when the amount of movement exceeds the threshold
+     */
+    void onFinish();
+
+    /**
+     * A callback if the threshold is not exceeded when release user finger
+     */
+    void onCancel();
+}

--- a/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
+++ b/photoview/src/main/java/com/github/chrisbanes/photoview/PhotoView.java
@@ -186,6 +186,10 @@ public class PhotoView extends AppCompatImageView {
         return attacher.getScale();
     }
 
+    public float getMinCloseThreshold() {
+        return attacher.getMinCloseThreshold();
+    }
+
     public void setAllowParentInterceptOnEdge(boolean allow) {
         attacher.setAllowParentInterceptOnEdge(allow);
     }
@@ -226,6 +230,10 @@ public class PhotoView extends AppCompatImageView {
         attacher.setOnViewDragListener(listener);
     }
 
+    public void setOnSwipeCloseListener(OnSwipeCloseListener listener) {
+        attacher.setOnSwipeCloseListener(listener);
+    }
+
     public void setScale(float scale) {
         attacher.setScale(scale);
     }
@@ -236,6 +244,10 @@ public class PhotoView extends AppCompatImageView {
 
     public void setScale(float scale, float focalX, float focalY, boolean animate) {
         attacher.setScale(scale, focalX, focalY, animate);
+    }
+
+    public void setMinCloseThreshold(float minCloseThreshold) {
+        attacher.setMinCloseThreshold(minCloseThreshold);
     }
 
     public void setZoomTransitionDuration(int milliseconds) {

--- a/sample/src/main/java/com/github/chrisbanes/photoview/sample/SimpleSampleActivity.java
+++ b/sample/src/main/java/com/github/chrisbanes/photoview/sample/SimpleSampleActivity.java
@@ -15,6 +15,7 @@
  */
 package com.github.chrisbanes.photoview.sample;
 
+import android.animation.ObjectAnimator;
 import android.graphics.Matrix;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
@@ -30,6 +31,7 @@ import android.widget.Toast;
 import com.github.chrisbanes.photoview.OnMatrixChangedListener;
 import com.github.chrisbanes.photoview.OnPhotoTapListener;
 import com.github.chrisbanes.photoview.OnSingleFlingListener;
+import com.github.chrisbanes.photoview.OnSwipeCloseListener;
 import com.github.chrisbanes.photoview.PhotoView;
 
 import java.util.Random;
@@ -139,6 +141,26 @@ public class SimpleSampleActivity extends AppCompatActivity {
         mPhotoView.setOnMatrixChangeListener(new MatrixChangeListener());
         mPhotoView.setOnPhotoTapListener(new PhotoTapListener());
         mPhotoView.setOnSingleFlingListener(new SingleFlingListener());
+        mPhotoView.setOnSwipeCloseListener(new OnSwipeCloseListener() {
+            @Override
+            public void onProgress(float delta) {
+                float threshold = mPhotoView.getMinCloseThreshold();
+                mPhotoView.setAlpha((threshold - Math.abs(delta))/threshold);
+            }
+
+            @Override
+            public void onFinish() {
+                finish();
+            }
+
+            @Override
+            public void onCancel() {
+                ObjectAnimator.ofFloat(mPhotoView, "translationY", mPhotoView.getTranslationY(), 0f)
+                        .setDuration(100L)
+                        .start();
+                mPhotoView.setAlpha(1.0f);
+            }
+        });
     }
 
     private class PhotoTapListener implements OnPhotoTapListener {


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Add feature

### :arrow_heading_down: What is the current behavior?
None

### :new: What is the new behavior (if this is a feature change)?
If you add OnSwipeCloseListener in PhotoView, you can swipe to do whatever you want.
 (I expect the screen to close smoothly like Google Photo.)

<img src="https://user-images.githubusercontent.com/50348316/110609583-b5e81a80-81d0-11eb-83e9-e2e32c6e4fef.gif" width="300"/>

### :boom: Does this PR introduce a breaking change?
None

### :bug: Recommendations for testing
None

### :memo: Links to relevant issues/docs
I think this feature is in demand. Please look at past issues.
https://github.com/Baseflow/PhotoView/issues/348

### :thinking: Checklist before submitting

- [ ✔ ] All projects build
- [ ✔ ] Follows style guide lines 
- [ ✔ ] Relevant documentation was updated
- [ ✔ ] Rebased onto current develop
