### PR TITLE
Remove JitPack repository from buildscript { ... } in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@ allprojects {
         maven { url "https://www.jitpack.io" }
     }
 }
-
-buildscript {
-    repositories {
-        maven { url "https://www.jitpack.io" }
-    }	
-}
 ```
 
 Then, add the library to your module `build.gradle`


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This PR removes the JitPack repository from `buildscript { repository { … } }` in `README` because it does not seem to be required.

### :arrow_heading_down: What is the current behavior?
`implementation 'com.github.chrisbanes:PhotoView:…'` can be resolved.

### :new: What is the new behavior (if this is a feature change)?
`implementation 'com.github.chrisbanes:PhotoView:…'` can be resolved. (unchanged)

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
